### PR TITLE
Fix syntax in prune cronjob template

### DIFF
--- a/templates/openshift-prune-cronjob.yml.j2
+++ b/templates/openshift-prune-cronjob.yml.j2
@@ -12,13 +12,13 @@ spec:
           - name: token
             secret:
               defaultMode: 420
-              secretName: {{ osbs_prune_secret }}
+              secretName: "{{ osbs_prune_secret }}"
           containers:
           - name: build-pruner
-            image: {{ osbs_prune_image }}
-            {-% if osbs_prune_commands %}
-            command: {{ osbs_prune_commands }}
-            {% endif -%}
+            image: "{{ osbs_prune_image }}"
+
+            {% if osbs_prune_commands %}command: {{ osbs_prune_commands }}{% endif %}
+
             volumeMounts:
             - mountPath: /token
               name: token


### PR DESCRIPTION
Adds quotes and new-lines to make sure the generated yaml
is correct and works (tested in osbs-box)