### PR TITLE
This PR fixes several issues with setup for pruning:

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,6 @@ osbs_nodeselector: ''
 
 osbs_prune: false
 osbs_prune_schedule: '0 0 */8 * *'
-osbs_prune_secret: ''
+osbs_prune_service_account: ''
 osbs_prune_image: ''
 osbs_prune_commands: ["/prune.sh"]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,6 +122,7 @@
 
   - name: osbs-pruner-serviceaccounts
     role: system:image-pruner
+    type: ClusterRoleBinding
     serviceaccounts: ["{{ osbs_serviceaccount_pruner }}"]
 
   register: yaml_rolebindings

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,6 +120,10 @@
     role_namespace: "{{ osbs_namespace }}"
     serviceaccounts: "{{ osbs_service_accounts }}"
 
+  - name: osbs-pruner-serviceaccounts
+    role: system:image-pruner
+    serviceaccounts: ["{{ osbs_serviceaccount_pruner }}"]
+
   register: yaml_rolebindings
   when: osbs_is_admin
   tags:

--- a/templates/openshift-prune-cronjob.yml.j2
+++ b/templates/openshift-prune-cronjob.yml.j2
@@ -13,6 +13,6 @@ spec:
           - name: build-pruner
             image: "{{ osbs_prune_image }}"
 
-            {% if osbs_prune_commands %}command: {{ osbs_prune_commands }}{% endif %}
+            {% if osbs_prune_commands %}command: {{ osbs_prune_commands | to_yaml }}{% endif %}
 
           restartPolicy: Never

--- a/templates/openshift-prune-cronjob.yml.j2
+++ b/templates/openshift-prune-cronjob.yml.j2
@@ -8,19 +8,11 @@ spec:
     spec:
       template:
         spec:
-          volumes:
-          - name: token
-            secret:
-              defaultMode: 420
-              secretName: "{{ osbs_prune_secret }}"
+          serviceAccountName: "{{ osbs_prune_serviceaccount }}"
           containers:
           - name: build-pruner
             image: "{{ osbs_prune_image }}"
 
             {% if osbs_prune_commands %}command: {{ osbs_prune_commands }}{% endif %}
 
-            volumeMounts:
-            - mountPath: /token
-              name: token
-              readOnly: true
           restartPolicy: Never

--- a/templates/openshift-rolebinding.v2.yml.j2
+++ b/templates/openshift-rolebinding.v2.yml.j2
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: RoleBinding
+kind: {{ item.type | default("RoleBinding") }}
 metadata:
   name: {{ item.name }}
   namespace: {{ osbs_namespace }}


### PR DESCRIPTION
* Run the pod as a serviceaccount to avoid mounting a secret
* Fix commands list convertion to yaml
* Add support to create cluster rolebindings
* Add system:image-pruner role to pruner SA so that it would have
  necessary permissions

Tested on osbs-box