### PR TITLE
Bump wait for pods to 2 hours

### DIFF
--- a/operations/defaults/main.yml
+++ b/operations/defaults/main.yml
@@ -11,8 +11,8 @@ osbs_node_labels: []
 osbs_managed_node_labels:
 - "auto_build=true"
 
-# Retry for about 20 minutes
-osbs_wait_active_pods_retries: 40
+# Retry for about 2 hours
+osbs_wait_active_pods_retries: 240
 osbs_wait_active_pods_delay: 30 # seconds
 
 # Wait for about 5 minutes


### PR DESCRIPTION
The previous period of 20 minutes may not have been
sufficient in some cases. Where system may be behaving
slower than usual due to either high load or slow
external services such as pulp.