### PR TITLE
osbs_namespace role: create a valid reactor-config-secret

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,3 +54,5 @@ osbs_serviceaccount_pruner: ''
 osbs_odcs_enabled: false
 osbs_odcs_signing_intents: {}
 osbs_odcs_default_signing_intent: null
+osbs_odcs_api_url: ''
+osbs_odcs_auth_ssl_certs_dir: /usr/share/osbs

--- a/templates/reactor-config-secret.yml.j2
+++ b/templates/reactor-config-secret.yml.j2
@@ -14,6 +14,9 @@ clusters:
 
 {% if osbs_odcs_enabled %}
 odcs:
+    api_url: {{ osbs_odcs_api_url }}
+    auth:
+        ssl_certs_dir: {{ osbs_odcs_auth_ssl_certs_dir }}
     signing_intents:
     {{ osbs_odcs_signing_intents | to_yaml | indent(4) }}
     default_signing_intent: {{ osbs_odcs_default_signing_intent }}


### PR DESCRIPTION
The schema for the atomic-reactor config secret was updated so that the
'odcs' section has required properties 'api_url' and 'auth', which are not
supplied by the osbs-namespace ansible role. Add them.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>