### PR TITLE
Cluster reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Role Name
-=========
+osbs-namespace
+==============
 
 Setup an OpenShift namespace as required by OSBS:
 - Create namespace, also referred to as project (`osbs_namespace`)
@@ -58,7 +58,7 @@ Role Variables
     - bot
     - ci
 
-    # User and groups to be assigned view clusterrole in specified namespace
+    # Users and groups to be assigned view clusterrole in specified namespace
     osbs_readonly_groups:
     - group1
     - group2

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ Role Variables
     - user1
     - user2
 
+    # Users and groups to be assigned cluster-reader clusterrole cluster wide
+    osbs_cluster_reader_groups:
+    - group1
+    - group2
+    osbs_cluster_reader_users:
+    - user1
+    - user2
+
     # Koji integration
     osbs_koji_secret_name: kojisecret
     osbs_koji_hub: https://koji.fedoraproject.org  # Empty default value

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ osbs_cpu_limitrange: ''
 
 osbs_admin_groups: []
 osbs_admin_users: []
+osbs_cluster_reader_groups: []
+osbs_cluster_reader_users: []
 osbs_readonly_groups: []
 osbs_readonly_users: []
 osbs_readwrite_groups: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,6 +89,13 @@
     role: system:build-strategy-custom
     serviceaccounts: "{{ osbs_service_accounts }}"
 
+  - name: osbs-cluster-reader
+    role: cluster-reader
+    yaml_version: v1
+    type: ClusterRoleBinding
+    users: "{{ osbs_cluster_reader_users }}"
+    groups: "{{ osbs_cluster_reader_groups }}"
+
   register: yaml_rolebindings
   when: osbs_is_admin
   tags:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -69,19 +69,11 @@
       oc -n test-worker get policybinding ':default'
     changed_when: false
 
-  - name: custom builds roles created
-    command: >
-      oc -n test-worker get role osbs-custom-build
-    changed_when: false
-
   - name: expected rolebindings created in worker namespace
     command: >
       oc -n test-worker get rolebinding {{ item }}
     with_items:
     - osbs-admin
-    - osbs-admin
-    - osbs-custom-build-admin
-    - osbs-custom-build-readwrite
     - osbs-custom-build-serviceaccounts
     - osbs-readonly
     - osbs-readwrite

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -302,3 +302,61 @@
     - osbs-readwrite
     - osbs-readwrite-serviceaccounts
     changed_when: false
+
+- name: setup users and groups in namespace
+  hosts: masters
+  roles:
+  - role: "{{ playbook_dir }}/../."
+    osbs_kubeconfig_path: "{{ lookup('env','HOME') }}/.kube/config"
+    osbs_openshift_home: tmp
+    osbs_namespace: test-users-and-groups
+    osbs_nodeselector: "worker=true"
+    osbs_admin_groups:
+    - admin-group
+    osbs_admin_users:
+    - admin-user
+    osbs_cluster_reader_groups:
+    - cluster-reader-group
+    osbs_cluster_reader_users:
+    - cluster-reader-user
+    osbs_readonly_groups:
+    - readonly-group
+    osbs_readonly_users:
+    - readonly-user
+    osbs_readwrite_groups:
+    - readwrite-group
+    osbs_readwrite_users:
+    - readwrite-user
+
+- name: test users and groups namespace
+  hosts: masters
+  vars:
+    osbs_users_groups_info:
+    - role_name: osbs-admin
+      type: rolebinding
+      expected: User Groupadmin-user admin-group
+    - role_name: osbs-readonly
+      type: rolebinding
+      expected: User Groupreadonly-user readonly-group
+    - role_name: osbs-readwrite
+      type: rolebinding
+      expected: User Groupreadwrite-user readwrite-group
+    - role_name: osbs-cluster-reader
+      type: clusterrolebinding
+      expected: User Groupcluster-reader-user cluster-reader-group
+  tasks:
+  - name: query rolebindings
+    command: >
+      oc -n test-users-and-groups get {{ item.type }} {{ item.role_name }}
+      -o jsonpath='{.subjects[*].kind}{.subjects[*].name}'
+    register: osbs_rolebindings
+    changed_when: false
+    with_items: "{{ osbs_users_groups_info }}"
+
+  - name: verify rolebindings
+    fail:
+      msg: "{{ item.1.type }} {{ item.1.role_name }} not as expected"
+    when: "item.0.stdout != item.1.expected"
+    with_together:
+    - "{{ osbs_rolebindings.results }}"
+    - "{{ osbs_users_groups_info }}"


### PR DESCRIPTION
Along with some fixes, this PR add support for adding users/groups to predefined cluster-reader clusterrole. It gives users access to the following:

```
#  oc describe clusterrole.rbac cluster-reader
Name:		cluster-reader
Labels:		<none>
Annotations:	authorization.openshift.io/system-only=true
		rbac.authorization.kubernetes.io/autoupdate=true
PolicyRule:
  Resources							Non-Resource URLs	Resource Names	Verbs
  ---------							-----------------	--------------	-----
  								[*]			[]		[get]
  apiservices.apiregistration.k8s.io				[]			[]		[get list watch]
  apiservices.apiregistration.k8s.io/status			[]			[]		[get list watch]
  appliedclusterresourcequotas					[]			[]		[get list watch]
  appliedclusterresourcequotas.quota.openshift.io		[]			[]		[get list watch]
  bindings							[]			[]		[get list watch]
  brokertemplateinstances					[]			[]		[get list watch]
  brokertemplateinstances.template.openshift.io			[]			[]		[get list watch]
  buildconfigs							[]			[]		[get list watch]
  buildconfigs.build.openshift.io				[]			[]		[get list watch]
  buildconfigs/webhooks						[]			[]		[get list watch]
  buildconfigs.build.openshift.io/webhooks			[]			[]		[get list watch]
  buildlogs							[]			[]		[get list watch]
  buildlogs.build.openshift.io					[]			[]		[get list watch]
  builds							[]			[]		[get list watch]
  builds.build.openshift.io					[]			[]		[get list watch]
  builds/details						[]			[]		[get list watch]
  builds.build.openshift.io/details				[]			[]		[get list watch]
  builds/log							[]			[]		[get list watch]
  builds.build.openshift.io/log					[]			[]		[get list watch]
  certificatesigningrequests.certificates.k8s.io		[]			[]		[get list watch]
  certificatesigningrequests.certificates.k8s.io/approval	[]			[]		[get list watch]
  certificatesigningrequests.certificates.k8s.io/status		[]			[]		[get list watch]
  clusternetworks						[]			[]		[get list watch]
  clusternetworks.network.openshift.io				[]			[]		[get list watch]
  clusterresourcequotas						[]			[]		[get list watch]
  clusterresourcequotas.quota.openshift.io			[]			[]		[get list watch]
  clusterresourcequotas/status					[]			[]		[get list watch]
  clusterresourcequotas.quota.openshift.io/status		[]			[]		[get list watch]
  clusterrolebindings						[]			[]		[get list watch]
  clusterrolebindings.authorization.openshift.io		[]			[]		[get list watch]
  clusterrolebindings.rbac.authorization.k8s.io			[]			[]		[get list watch]
  clusterroles							[]			[]		[get list watch]
  clusterroles.authorization.openshift.io			[]			[]		[get list watch]
  clusterroles.rbac.authorization.k8s.io			[]			[]		[get list watch]
  componentstatuses						[]			[]		[get list watch]
  configmaps							[]			[]		[get list watch]
  controllerrevisions.apps					[]			[]		[get list watch]
  cronjobs.batch						[]			[]		[get list watch]
  cronjobs.batch/status						[]			[]		[get list watch]
  customresourcedefinitions.apiextensions.k8s.io		[]			[]		[get list watch]
  customresourcedefinitions.apiextensions.k8s.io/status		[]			[]		[get list watch]
  daemonsets.extensions						[]			[]		[get list watch]
  daemonsets.extensions/status					[]			[]		[get list watch]
  deploymentconfigs						[]			[]		[get list watch]
  deploymentconfigs.apps.openshift.io				[]			[]		[get list watch]
  deploymentconfigs/log						[]			[]		[get list watch]
  deploymentconfigs.apps.openshift.io/log			[]			[]		[get list watch]
  deploymentconfigs/scale					[]			[]		[get list watch]
  deploymentconfigs.apps.openshift.io/scale			[]			[]		[get list watch]
  deploymentconfigs/status					[]			[]		[get list watch]
  deploymentconfigs.apps.openshift.io/status			[]			[]		[get list watch]
  deployments.apps						[]			[]		[get list watch]
  deployments.extensions					[]			[]		[get list watch]
  deployments.apps/scale					[]			[]		[get list watch]
  deployments.extensions/scale					[]			[]		[get list watch]
  deployments.apps/status					[]			[]		[get list watch]
  deployments.extensions/status					[]			[]		[get list watch]
  egressnetworkpolicies						[]			[]		[get list watch]
  egressnetworkpolicies.network.openshift.io			[]			[]		[get list watch]
  endpoints							[]			[]		[get list watch]
  events							[]			[]		[get list watch]
  groups							[]			[]		[get list watch]
  groups.user.openshift.io					[]			[]		[get list watch]
  horizontalpodautoscalers.autoscaling				[]			[]		[get list watch]
  horizontalpodautoscalers.extensions				[]			[]		[get list watch]
  horizontalpodautoscalers.autoscaling/status			[]			[]		[get list watch]
  horizontalpodautoscalers.extensions/status			[]			[]		[get list watch]
  hostsubnets							[]			[]		[get list watch]
  hostsubnets.network.openshift.io				[]			[]		[get list watch]
  identities							[]			[]		[get list watch]
  identities.user.openshift.io					[]			[]		[get list watch]
  images							[]			[]		[get list watch]
  images.image.openshift.io					[]			[]		[get list watch]
  imagesignatures						[]			[]		[get list watch]
  imagesignatures.image.openshift.io				[]			[]		[get list watch]
  imagestreamimages						[]			[]		[get list watch]
  imagestreamimages.image.openshift.io				[]			[]		[get list watch]
  imagestreams							[]			[]		[get list watch]
  imagestreams.image.openshift.io				[]			[]		[get list watch]
  imagestreams/layers						[]			[]		[get]
  imagestreams.image.openshift.io/layers			[]			[]		[get]
  imagestreams/status						[]			[]		[get list watch]
  imagestreams.image.openshift.io/status			[]			[]		[get list watch]
  imagestreamtags						[]			[]		[get list watch]
  imagestreamtags.image.openshift.io				[]			[]		[get list watch]
  ingresses.extensions						[]			[]		[get list watch]
  ingresses.extensions/status					[]			[]		[get list watch]
  jobs.batch							[]			[]		[get list watch]
  jobs.extensions						[]			[]		[get list watch]
  jobs.batch/status						[]			[]		[get list watch]
  jobs.extensions/status					[]			[]		[get list watch]
  limitranges							[]			[]		[get list watch]
  localresourceaccessreviews					[]			[]		[create]
  localresourceaccessreviews.authorization.openshift.io		[]			[]		[create]
  localsubjectaccessreviews					[]			[]		[create]
  localsubjectaccessreviews.authorization.k8s.io		[]			[]		[create]
  localsubjectaccessreviews.authorization.openshift.io		[]			[]		[create]
  namespaces							[]			[]		[get list watch]
  namespaces/status						[]			[]		[get list watch]
  netnamespaces							[]			[]		[get list watch]
  netnamespaces.network.openshift.io				[]			[]		[get list watch]
  networkpolicies.extensions					[]			[]		[get list watch]
  networkpolicies.networking.k8s.io				[]			[]		[get list watch]
  nodes								[]			[]		[get list watch]
  nodes/metrics							[]			[]		[get]
  nodes/spec							[]			[]		[get]
  nodes/stats							[]			[]		[create get]
  nodes/status							[]			[]		[get list watch]
  oauthclientauthorizations					[]			[]		[get list watch]
  oauthclientauthorizations.oauth.openshift.io			[]			[]		[get list watch]
  persistentvolumeclaims					[]			[]		[get list watch]
  persistentvolumeclaims/status					[]			[]		[get list watch]
  persistentvolumes						[]			[]		[get list watch]
  persistentvolumes/status					[]			[]		[get list watch]
  poddisruptionbudgets.policy					[]			[]		[get list watch]
  poddisruptionbudgets.policy/status				[]			[]		[get list watch]
  podpresets.settings.k8s.io					[]			[]		[get list watch]
  pods								[]			[]		[get list watch]
  pods/binding							[]			[]		[get list watch]
  pods/eviction							[]			[]		[get list watch]
  pods/log							[]			[]		[get list watch]
  pods/status							[]			[]		[get list watch]
  podsecuritypolicies.extensions				[]			[]		[get list watch]
  podsecuritypolicyreviews					[]			[]		[create]
  podsecuritypolicyreviews.security.openshift.io		[]			[]		[create]
  podsecuritypolicyselfsubjectreviews				[]			[]		[create]
  podsecuritypolicyselfsubjectreviews.security.openshift.io	[]			[]		[create]
  podsecuritypolicysubjectreviews				[]			[]		[create]
  podsecuritypolicysubjectreviews.security.openshift.io		[]			[]		[create]
  podtemplates							[]			[]		[get list watch]
  processedtemplates						[]			[]		[get list watch]
  processedtemplates.template.openshift.io			[]			[]		[get list watch]
  projectrequests						[]			[]		[get list watch]
  projectrequests.project.openshift.io				[]			[]		[get list watch]
  projects							[]			[]		[get list watch]
  projects.project.openshift.io					[]			[]		[get list watch]
  replicasets.extensions					[]			[]		[get list watch]
  replicasets.extensions/scale					[]			[]		[get list watch]
  replicasets.extensions/status					[]			[]		[get list watch]
  replicationcontrollers					[]			[]		[get list watch]
  replicationcontrollers.extensions				[]			[]		[get list watch]
  replicationcontrollers/scale					[]			[]		[get list watch]
  replicationcontrollers.extensions/scale			[]			[]		[get list watch]
  replicationcontrollers/status					[]			[]		[get list watch]
  resourceaccessreviews						[]			[]		[create]
  resourceaccessreviews.authorization.openshift.io		[]			[]		[create]
  resourcequotas						[]			[]		[get list watch]
  resourcequotas/status						[]			[]		[get list watch]
  resourcequotausages						[]			[]		[get list watch]
  rolebindingrestrictions					[]			[]		[get list watch]
  rolebindingrestrictions.authorization.openshift.io		[]			[]		[get list watch]
  rolebindings							[]			[]		[get list watch]
  rolebindings.authorization.openshift.io			[]			[]		[get list watch]
  rolebindings.rbac.authorization.k8s.io			[]			[]		[get list watch]
  roles								[]			[]		[get list watch]
  roles.authorization.openshift.io				[]			[]		[get list watch]
  roles.rbac.authorization.k8s.io				[]			[]		[get list watch]
  routes							[]			[]		[get list watch]
  routes.route.openshift.io					[]			[]		[get list watch]
  routes/status							[]			[]		[get list watch]
  routes.route.openshift.io/status				[]			[]		[get list watch]
  scheduledjobs.batch						[]			[]		[get list watch]
  scheduledjobs.batch/status					[]			[]		[get list watch]
  securitycontextconstraints					[]			[]		[get list watch get list watch]
  securitycontextconstraints.security.openshift.io		[]			[]		[get list watch]
  selfsubjectaccessreviews.authorization.k8s.io			[]			[]		[create]
  selfsubjectrulesreviews					[]			[]		[create]
  selfsubjectrulesreviews.authorization.openshift.io		[]			[]		[create]
  serviceaccounts						[]			[]		[get list watch]
  services							[]			[]		[get list watch]
  services/status						[]			[]		[get list watch]
  statefulsets.apps						[]			[]		[get list watch]
  statefulsets.apps/status					[]			[]		[get list watch]
  storageclasses.extensions					[]			[]		[get list watch]
  storageclasses.storage.k8s.io					[]			[]		[get list watch]
  subjectaccessreviews						[]			[]		[create]
  subjectaccessreviews.authorization.k8s.io			[]			[]		[create]
  subjectaccessreviews.authorization.openshift.io		[]			[]		[create]
  subjectrulesreviews						[]			[]		[create]
  subjectrulesreviews.authorization.openshift.io		[]			[]		[create]
  templateconfigs						[]			[]		[get list watch]
  templateconfigs.template.openshift.io				[]			[]		[get list watch]
  templateinstances						[]			[]		[get list watch]
  templateinstances.template.openshift.io			[]			[]		[get list watch]
  templateinstances/status					[]			[]		[get list watch]
  templateinstances.template.openshift.io/status		[]			[]		[get list watch]
  templates							[]			[]		[get list watch]
  templates.template.openshift.io				[]			[]		[get list watch]
  thirdpartyresources.extensions				[]			[]		[get list watch]
  tokenreviews.authentication.k8s.io				[]			[]		[create]
  useridentitymappings						[]			[]		[get list watch]
  useridentitymappings.user.openshift.io			[]			[]		[get list watch]
  users								[]			[]		[get list watch]
  users.user.openshift.io					[]			[]		[get list watch]
```