### PR TITLE
Do not use cluster role binding if not needed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,14 +70,12 @@
   - name: osbs-custom-build-readwrite
     role: system:build-strategy-custom
     yaml_version: v1
-    type: ClusterRoleBinding
     users: "{{ osbs_readwrite_users }}"
     groups: "{{ osbs_readwrite_groups }}"
 
   - name: osbs-custom-build-admin
     role: system:build-strategy-custom
     yaml_version: v1
-    type: ClusterRoleBinding
     users: "{{ osbs_admin_users }}"
     groups: "{{ osbs_admin_groups }}"
 


### PR DESCRIPTION
custom read write roles do not need to be applied at cluster level.
Instead use regular role binding to add permission on a per project
basis.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>