### PR TITLE
Bug-fixes for pruner.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,10 +59,11 @@ osbs_pruner_command_build:
 - /usr/bin/oc
 - adm
 - prune
+- "--namespace={{ osbs_namespace }}"
 - builds
 - --orphans=true
 - --confirm
 osbs_pruner_schedule_build: "0 0 * * *"
 osbs_pruner_successful_jobs: 5
 osbs_pruner_failed_jobs: 5
-osbs_pruner_clusterrole_build: system:openshift:controller:build-controller
+osbs_pruner_clusterrole_build: system:openshift:controller:build-config-change-controller

--- a/tasks/pruner.yml
+++ b/tasks/pruner.yml
@@ -25,9 +25,19 @@
     src: "openshift-rolebinding.v2.yml.j2"
     dest: "{{ osbs_openshift_home }}/{{ inventory_hostname }}-{{ osbs_namespace }}-rolebinding-{{ item.name }}.yml"
   with_items:
-  - name: build-pruner
+  # For listing builds
+  - name: "{{ osbs_namespace }}-build-pruner-read"
+    role: "view"
+    serviceaccounts:
+    - "{{ osbs_pruner_serviceaccount }}"
+  # For listing buildconfigs and deleting builds
+  # Must allow listing buildconfigs across all namespaces due to
+  # this being required by 'oc adm prune'
+  - name: "{{ osbs_namespace }}-build-pruner-delete"
     role: "{{ osbs_pruner_clusterrole_build }}"
-    serviceaccounts: "{{ osbs_pruner_serviceaccount }}"
+    type: ClusterRoleBinding
+    serviceaccounts:
+    - "{{ osbs_pruner_serviceaccount }}"
   register: yaml_rolebindings
   when: osbs_is_admin
   tags:


### PR DESCRIPTION
For the rolebinding task, serviceaccounts is meant to be a list but was
being set to a string. As a result the template tried to create a new
service account for each character.

The CronJob command now limits the pruning operation to a single
namespace.

Additionally, the rolebinding needs to be a clusterrolebinding because
'oc adm' requires cluster-wide permissions even when limiting its
operation to a single namespace.

Further, both cluster-reader (to list BuildConfigs) and
build-config-change-controller (to delete Builds) cluster roles need to
be included in the binding.

Finally, the name of the clusterrolebinding needs to include the
namespace to avoid collisions when run for multiple namespaces in the
cluster.

Signed-off-by: Tim Waugh <twaugh@redhat.com>