### PR TITLE
Fix pruner permissions.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,4 +66,5 @@ osbs_pruner_command_build:
 osbs_pruner_schedule_build: "0 0 * * *"
 osbs_pruner_successful_jobs: 5
 osbs_pruner_failed_jobs: 5
-osbs_pruner_clusterrole_build: system:openshift:controller:build-config-change-controller
+osbs_pruner_build_clusterrole_read: system:openshift:controller:build-config-change-controller
+osbs_pruner_build_role_delete: edit

--- a/tasks/pruner.yml
+++ b/tasks/pruner.yml
@@ -25,17 +25,17 @@
     src: "openshift-rolebinding.v2.yml.j2"
     dest: "{{ osbs_openshift_home }}/{{ inventory_hostname }}-{{ osbs_namespace }}-rolebinding-{{ item.name }}.yml"
   with_items:
-  # For listing builds
-  - name: "{{ osbs_namespace }}-build-pruner-read"
-    role: "view"
-    serviceaccounts:
-    - "{{ osbs_pruner_serviceaccount }}"
-  # For listing buildconfigs and deleting builds
+  # For listing buildconfigs and builds
   # Must allow listing buildconfigs across all namespaces due to
   # this being required by 'oc adm prune'
-  - name: "{{ osbs_namespace }}-build-pruner-delete"
-    role: "{{ osbs_pruner_clusterrole_build }}"
+  - name: "{{ osbs_namespace }}-build-pruner-read"
+    role: "{{ osbs_pruner_build_clusterrole_read }}"
     type: ClusterRoleBinding
+    serviceaccounts:
+    - "{{ osbs_pruner_serviceaccount }}"
+  # For deleting builds (in this namespace only)
+  - name: "{{ osbs_namespace }}-build-pruner-delete"
+    role: "{{ osbs_pruner_build_role_delete }}"
     serviceaccounts:
     - "{{ osbs_pruner_serviceaccount }}"
   register: yaml_rolebindings


### PR DESCRIPTION
The system:openshift:controller:build-config-change-controller
cluster-role grants the ability to list BuildConfigs cluster-wide, which
'oc adm prune builds' requires.

The 'edit' role provides the ability to list and delete Builds in the
project namespace.

Signed-off-by: Tim Waugh <twaugh@redhat.com>